### PR TITLE
`payable` constructor & custom error `FEE_MAX` includes emitter

### DIFF
--- a/src/mods/Subsidized.sol
+++ b/src/mods/Subsidized.sol
@@ -11,14 +11,26 @@ import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
 abstract contract Refunded is ReentrancyGuard {
     using SafeTransferLib for address;
 
-    /// @dev Emitted if gas price over limit.
-    error FEE_MAX();
+    /** 
+     * @dev Emitted if gas price over limit.
+     * @param emitter The contract that emits the error.
+     */
+    error FEE_MAX(address emitter);
 
     /// @dev Gas fee for modifier.
     uint256 internal constant BASE_FEE = 25433;
 
     /// @dev Reasonable limit for gas price.
     uint256 internal constant MAX_FEE = 4e10; // 4*10**10
+
+    /**
+     * @dev You can cut out 10 opcodes in the creation-time EVM bytecode
+     * if you declare a constructor `payable`.
+     *
+     * For more in-depth information see here:
+     * https://forum.openzeppelin.com/t/a-collection-of-gas-optimisation-tricks/19966/5
+     */
+    constructor() payable {}
 
     receive() external payable virtual {}
     
@@ -34,7 +46,7 @@ abstract contract Refunded is ReentrancyGuard {
 
         // Check malicious refund against gas price limit.
         unchecked {
-            if (tx.gasprice > block.basefee + MAX_FEE) revert FEE_MAX();
+            if (tx.gasprice > block.basefee + MAX_FEE) revert FEE_MAX(address(this));
         }
 
         // Run modified function.

--- a/src/mods/Subsidized.sol
+++ b/src/mods/Subsidized.sol
@@ -11,10 +11,8 @@ import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
 abstract contract Refunded is ReentrancyGuard {
     using SafeTransferLib for address;
 
-    /** 
-     * @dev Emitted if gas price over limit.
-     * @param emitter The contract that emits the error.
-     */
+    /// @dev Emitted if gas price over limit.
+    /// @param emitter The contract that emits the error.
     error FEE_MAX(address emitter);
 
     /// @dev Gas fee for modifier.
@@ -23,13 +21,10 @@ abstract contract Refunded is ReentrancyGuard {
     /// @dev Reasonable limit for gas price.
     uint256 internal constant MAX_FEE = 4e10; // 4*10**10
 
-    /**
-     * @dev You can cut out 10 opcodes in the creation-time EVM bytecode
-     * if you declare a constructor `payable`.
-     *
-     * For more in-depth information see here:
-     * https://forum.openzeppelin.com/t/a-collection-of-gas-optimisation-tricks/19966/5
-     */
+    /// @dev You can cut out 10 opcodes in the creation-time EVM bytecode
+    /// if you declare a constructor `payable`.
+    /// For more in-depth information see here:
+    /// https://forum.openzeppelin.com/t/a-collection-of-gas-optimisation-tricks/19966/5
     constructor() payable {}
 
     receive() external payable virtual {}


### PR DESCRIPTION
This PR suggests the following changes:
- `payable` constructor: You can cut out 10 opcodes in the creation-time EVM bytecode if you declare a constructor `payable`.
- custom error `FEE_MAX` includes emitter: This helps end-users identify which contract was reverted with a failed transaction, which is especially useful for complex transactions involving multiple contracts.