### PR TITLE
Stateless Epoch

### DIFF
--- a/src/test/StatelessEpoch.t.sol
+++ b/src/test/StatelessEpoch.t.sol
@@ -15,13 +15,16 @@ contract StatelessEpochTest is Test {
         
         mock = new MockEpoch();
 
+        // gas reports are according to forge
+        // I got different values on rinkeby :thonk:
+
         // incrementing epoch 0 to 1 costs 22,247 gas
         mock.incrementEpoch();
 
         // incrementing epoch 1 to 2 costs 11,297 gas
         mock.incrementEpoch();
 
-        // incrementing epochCounter[2] from 0 to 1 costs 22,469 gas 
+        // incrementing epochCounter[2] from 0 to 1 costs 22,469 gas
         mock.useEpoch();
 
         // incrementing epochCounter[2534796] from 0 to 1 costs 22,435 gas
@@ -35,12 +38,4 @@ contract StatelessEpochTest is Test {
     function testStatelessEpoch() public {
         mock.useStatelessEpoch();
     }
-    // function testA() public {
-    //     mock.useStatelessEpoch();
-    //     mock.useEpoch();
-    // }
-    // function testB() public {
-    //     mock.useEpoch();
-    //     mock.useStatelessEpoch();
-    // }
 }

--- a/src/test/StatelessEpoch.t.sol
+++ b/src/test/StatelessEpoch.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.4;
+
+import {MockEpoch} from "./utils/mocks/MockEpoch.sol";
+
+import "@std/Test.sol";
+
+contract StatelessEpochTest is Test {
+    using stdStorage for StdStorage;
+
+    MockEpoch mock;
+
+    function setUp() public {
+        console.log(unicode"🧪 Testing StatlessEpoch...");
+        
+        mock = new MockEpoch();
+
+        // incrementing epoch 0 to 1 costs 22,247 gas
+        mock.incrementEpoch();
+
+        // incrementing epoch 1 to 2 costs 11,297 gas
+        mock.incrementEpoch();
+
+        // incrementing epochCounter[2] from 0 to 1 costs 22,469 gas 
+        mock.useEpoch();
+
+        // incrementing epochCounter[2534796] from 0 to 1 costs 22,435 gas
+        mock.useStatelessEpoch();
+    }
+
+    function testEpoch() public {
+        mock.useEpoch();
+    }
+
+    function testStatelessEpoch() public {
+        mock.useStatelessEpoch();
+    }
+    // function testA() public {
+    //     mock.useStatelessEpoch();
+    //     mock.useEpoch();
+    // }
+    // function testB() public {
+    //     mock.useEpoch();
+    //     mock.useStatelessEpoch();
+    // }
+}

--- a/src/test/utils/mocks/MockEpoch.sol
+++ b/src/test/utils/mocks/MockEpoch.sol
@@ -3,6 +3,10 @@ pragma solidity >=0.8.4;
 
 import {StatelessEpoch} from "../../../utils/StatelessEpoch.sol";
 
+// TESTNET DEPLOYMENT: https://rinkeby.etherscan.io/address/0x1fabebc948c313894cd46b277dceb1319440e021
+// useStatelessEpoch()  26,399 gas
+// useEpoch()           28,433 gas
+
 /// @notice An example contract that inherits and utilizes StatelessEpoch
 contract MockEpoch is StatelessEpoch {
     // a typical state epoch thats managed by external calls (incrementEpoch())

--- a/src/test/utils/mocks/MockEpoch.sol
+++ b/src/test/utils/mocks/MockEpoch.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.4;
+
+import {StatelessEpoch} from "../../../utils/StatelessEpoch.sol";
+
+/// @notice An example contract that inherits and utilizes StatelessEpoch
+contract MockEpoch is StatelessEpoch {
+    // a typical state epoch thats managed by external calls (incrementEpoch())
+    uint256 public epoch;
+
+    // a mock state variable in which epoch is utilized
+    // maps epoch => counter
+    mapping(uint256 => uint256) public epochCounter;
+
+
+    function useEpoch() public {
+        unchecked { epochCounter[epoch]++; }
+    }
+
+    function incrementEpoch() public {
+        unchecked { epoch++; }
+    }
+
+    function useStatelessEpoch() public {
+        unchecked { epochCounter[getEpoch()]++; }
+    }
+
+    function epochPeriod() public pure override returns (uint256) {
+        // monthly epochs (seconds per month)
+        // (60 * 60 * 24 * 365) / 12 = 2628000
+        return 2628000;
+    }
+}

--- a/src/test/utils/mocks/MockEpoch.sol
+++ b/src/test/utils/mocks/MockEpoch.sol
@@ -12,22 +12,25 @@ contract MockEpoch is StatelessEpoch {
     // maps epoch => counter
     mapping(uint256 => uint256) public epochCounter;
 
-
-    function useEpoch() public {
-        unchecked { epochCounter[epoch]++; }
-    }
-
-    function incrementEpoch() public {
-        unchecked { epoch++; }
-    }
-
-    function useStatelessEpoch() public {
-        unchecked { epochCounter[getEpoch()]++; }
-    }
-
+    // Override the epochPeriod which is required when inheriting from StatelessEpoch
     function epochPeriod() public pure override returns (uint256) {
         // monthly epochs (seconds per month)
         // (60 * 60 * 24 * 365) / 12 = 2628000
         return 2628000;
+    }
+
+    // example usage of a state epoch
+    function useEpoch() public {
+        unchecked { epochCounter[epoch]++; }
+    }
+
+    // example usage of manually incrementing an epoch
+    function incrementEpoch() public {
+        unchecked { epoch++; }
+    }
+
+    // example usage of a stateless epoch
+    function useStatelessEpoch() public {
+        unchecked { epochCounter[getEpoch()]++; }
     }
 }

--- a/src/utils/StatelessEpoch.sol
+++ b/src/utils/StatelessEpoch.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.4;
+
+/// @notice Stateless, self-updating epochs for smart contracts.
+/// @author saucepoint
+/// @dev Be conscious of abuse by miners which can modify block.timestamp
+abstract contract StatelessEpoch {
+    /// Look mom, no state!
+
+    /// @dev Override this function in the child contract
+    /// The value returned by this view function is the number of seconds between each epoch
+    function epochPeriod() public pure virtual returns (uint256) {
+        return 0;
+    }
+
+    function getEpoch() public view returns (uint256) {
+        return block.timestamp % epochPeriod();
+    }
+}

--- a/src/utils/StatelessEpoch.sol
+++ b/src/utils/StatelessEpoch.sol
@@ -3,17 +3,19 @@ pragma solidity >=0.8.4;
 
 /// @notice Stateless, self-updating epochs for smart contracts.
 /// @author saucepoint
-/// @dev Be conscious of abuse by miners which can modify block.timestamp
+/// @dev Be conscious of abuse by miners which can deviate block.timestamp
 abstract contract StatelessEpoch {
     /// Look mom, no state!
 
     /// @dev Override this function in the child contract
     /// The value returned by this view function is the number of seconds between each epoch
+    /// Dont forget to test your code! Forgetting to override this function will result in a
+    /// divide by zero error in `getEpoch()`
     function epochPeriod() public pure virtual returns (uint256) {
         return 0;
     }
 
     function getEpoch() public view returns (uint256) {
-        return block.timestamp % epochPeriod();
+        return block.timestamp / epochPeriod();
     }
 }


### PR DESCRIPTION
Cooked up a fun little utility primitive regarding epochs. Saves about ~2,000 gas compared to using a state-based epoch.

As a bonus, it self-updates so it doesn't require an external transaction to set a new epoch.

---

Main use-cases are when you need a unique ID to identify a period of time. An example would be claiming revenue-share on a monthly basis. Or you want to restrict the number of actions (mints, loans, deposits) per day. 