### PR TITLE
opt(reentrancy-guard): using transient storage to optimize reentrancy guard

### DIFF
--- a/src/ReentrancyGuard.sol
+++ b/src/ReentrancyGuard.sol
@@ -2,16 +2,30 @@
 pragma solidity ^0.8.27;
 
 /// @notice Reentrant call guard.
-/// @author Zolidity (https://github.com/z0r0z/zolidity/blob/main/src/ReentrancyGuard.sol)
+/// @author SocksNFlops + Zolidity (https://github.com/z0r0z/zolidity/blob/main/src/ReentrancyGuard.sol)
 abstract contract ReentrancyGuard {
+    bytes32 private constant REENTRANCY_LOCK_SLOT = keccak256("zolidity.reentrancy.lock");
+
     error Reentrancy();
 
-    uint256 internal _guard = 1;
-
     modifier nonReentrant() virtual {
-        require(_guard == 1, Reentrancy());
-        _guard = 2;
+        bytes32 slot = REENTRANCY_LOCK_SLOT;
+        bytes32 errorSelector = Reentrancy.selector;
+        // Check if the lock is set. Revert if it is, otherwise set the lock.
+        assembly {
+            // Load the transient storage value
+            if tload(slot) {
+                // If already locked, revert
+                mstore(0x00, errorSelector)
+                revert(0x00, 0x04)
+            }
+            // Set lock
+            tstore(slot, 1)
+        }
         _;
-        _guard = 1;
+        // Clear the lock
+        assembly {
+            tstore(slot, 0)
+        }
     }
 }

--- a/test/ReentrancyGuard.t.sol
+++ b/test/ReentrancyGuard.t.sol
@@ -16,6 +16,14 @@ contract MockReentrant is ReentrancyGuard {
         counter++;
         if (counter == 1) this.unprotectedFunction();
     }
+
+    function getReentrancyGuard() external view returns (uint256 value) {
+        bytes32 slot = keccak256("zolidity.reentrancy.lock");
+        assembly {
+            // Load the transient storage value
+            value := tload(slot)
+        }
+    }
 }
 
 contract ReentrancyGuardTest is Test {
@@ -37,7 +45,7 @@ contract ReentrancyGuardTest is Test {
 
     function testGuardValueReset() public {
         try mock.protectedFunction() {} catch {}
-        uint256 slot0 = uint256(vm.load(address(mock), bytes32(0)));
-        assertEq(slot0, 1, "Guard should be reset to 1");
+        uint256 slotvalue = mock.getReentrancyGuard();
+        assertEq(slotvalue, 0, "Guard should be reset to 0");
     }
 }


### PR DESCRIPTION
## Changes:
- Reimplemented `ReentrancyGuard.sol` to leverage transient storage
- Open to feedback & suggestions to improve PR

## Tests:
- Outperforms everywhere except slightly in the allow-reentrancy test.

| Before | After |
|-|-|
| [PASS] testGuardValueReset() (gas: 36965) | [PASS] testGuardValueReset() (gas: 32474) |
| [PASS] testProtectedFunctionPreventsReentrancy() (gas: 36096) | [PASS] testProtectedFunctionPreventsReentrancy() (gas: 31268) |
| [PASS] testUnprotectedFunctionAllowsReentrancy() (gas: 32284) | [PASS] testUnprotectedFunctionAllowsReentrancy() (gas: 32325) |

## Reviewers:
@z0r0z 